### PR TITLE
Backwards compatible changes to source to support MCLK disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 2.2.0
+
+  * Support runtime disabling of MCLK drive to allow for I2S role change
+
 ## 2.1.0
 
   * Enable SPI interface

--- a/resources/clk_dac_setup/setup_mclk_bclk.c
+++ b/resources/clk_dac_setup/setup_mclk_bclk.c
@@ -295,7 +295,18 @@ int main(int argc, char *argv[])
     }
 
 #ifdef MCLK
-    gpioSetMode(4, PI_ALT0); //set GPCLK0 mode to alternate functionality
+    unsigned mclk_mode =  PI_ALT0; //set GPCLK0 mode to alternate functionality (clock)
+
+    if (argc > 1){
+        if (!strcmp(argv[1], "--disable")){
+            mclk_mode = PI_INPUT; //set GPCLK0 mode to input pin (switch clock off)
+	    printf("Disabling MCLK output\n");
+	}
+	else{
+	    printf("unknown option %s\n", argv[1]);
+	}
+    }
+    gpioSetMode(4, mclk_mode);
 #endif //MCLK
 
     //leave the clocks running and exit


### PR DESCRIPTION
As above - allow switching off of the Raspberry Pi MCLK at runtime to support dynamic I2S role change