### PR TITLE
Add 16k support for BCLK in synch with mclk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 2.3.0
+
+  * Add support for 16kHz BCLK generation
+
 ## 2.2.0
 
   * Support runtime disabling of MCLK drive to allow for I2S role change

--- a/resources/clk_dac_setup/setup_mclk_bclk.c
+++ b/resources/clk_dac_setup/setup_mclk_bclk.c
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
     if (argc > 1){
         if (!strcmp(argv[1], "16000")){
 	    i2s_16000 = 1; 
-	    printf("USing LRCLK 16000Hz\n");
+	    printf("Using LRCLK of 16000Hz\n");
 	}
 	else{
 	    printf("unknown option %s\n", argv[1]);

--- a/resources/clk_dac_setup/setup_mclk_bclk.c
+++ b/resources/clk_dac_setup/setup_mclk_bclk.c
@@ -277,11 +277,30 @@ int main(int argc, char *argv[])
     printf("MCLK: Using %s (I=%-4d F=%-4d MASH=%d)\n",
             clocks[clk_source], clk_i, clk_f, clk_mash);
 #else
+    int i2s_16000 = 0;
+    if (argc > 1){
+        if (!strcmp(argv[1], "16000")){
+	    i2s_16000 = 1; 
+	    printf("USing LRCLK 16000Hz\n");
+	}
+	else{
+	    printf("unknown option %s\n", argv[1]);
+	}
+    }
+    else{
+        printf("Using LRCLK 48000Hz\n");
+    }
+
     int clk_index = 2;
     int clk_source = 0;
     int clk_mash = 1;
     int clk_i = 162;
     int clk_f = 3112;
+    if(i2s_16000)
+    {
+	    clk_i = 488;
+	    clk_f = 1144;
+    }
     int clk_enable = 0;
 
     printf("CLK: Using %s (I=%-4d F=%-4d MASH=%d)\n",


### PR DESCRIPTION
As per above. Necessary for when you want to generate 16kHz I2S which is phase locked to mclk. Used in the _INT test harness.
Backwards compatible change.