### PR TITLE
Update reset_xvf3510.py for 3610 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ For XVF3510 devices these actions will be done as well:
    For XVF3510 devices, run the installation script as follows:
 
    ```./setup.sh xvf3510```
+   
+   For XVF3610 devices, run the installation script as follows:
+
+   ```./setup.sh xvf3610```
 
    Wait for the script to complete the installation. This can take several minutes.
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,27 @@ For XVF3510 devices these actions will be done as well:
 
 ## Setup
 
-1. Install **Raspbian Buster** on the Raspberry Pi.
+1. First, obtain the required version of the Raspberry Pi operating system, which is available here:
 
-2. Ensure running kernel version matches headers kernel headers package. A typical system requires the following `--reinstall` command:
+   https://downloads.raspberrypi.org/raspbian/images/raspbian-2020-02-14/2020-02-13-raspbian-buster.zip
 
-   ```sudo apt-get update```
-   ```sudo apt-get install --reinstall raspberrypi-bootloader raspberrypi-kernel```
+   We cannot use the latest as updates to linux kernel v5 have broken the I2S sub-system.
 
-   followed by a reboot.
+   Then, install the Raspberry Pi Imager on a host computer. Raspberry Pi Imager is available here:
+
+   https://www.raspberrypi.org/software/
+
+   Run the Raspberry Pi Imager, and select the 'CHOOSE OS' button. Scroll to the bottom of the displayed list, and select "Use custom". 
+   Then select the file downloaded above (2020-02-13-raspbian-buster.zip) and select "Open". The archive file does not have to be unzipped, the imager software will do that.
+
+   Select the CHOOSE SD CARD button to which to download the image, and then select the "WRITE" button.
+
+   When prompted, remove the written SD card and insert it into the Raspberry Pi. 
+
+2. Connect up the keyboard, mouse, speakers and display to the Raspberry Pi and power up the system. Refer to the **Getting Started Guide** for you platform.
+
+   **DO NOT** follow the prompt to update the software on the system. Set up the locale, and setup a network connect, but **DO NOT** update the software on the Raspberry Pi. This will update the kernel, and then the audio sub-system will not work.
+
 
 3. Clone the Github repository https://github.com/xmos/vocalfusion-rpi-setup:
 

--- a/resources/clk_dac_setup/reset_xvf.py
+++ b/resources/clk_dac_setup/reset_xvf.py
@@ -37,12 +37,12 @@ def reset(args):
     data_to_write = 0x20 | (state[6] & 0xDF)
     bus.write_byte_data(0x20, 6, data_to_write)
     
-    if level_shifters:
+    if level_shifter:
         # turn on level shifters on 3610 pi Hat
         bus.write_byte_data(0x20, 3, 0x00)
         bus.write_byte_data(0x20, 7, 0xD7)
     
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("hw", desc="Hardware type")
+    parser.add_argument("hw", help="Hardware type")
     reset(parser.parse_args())

--- a/resources/clk_dac_setup/reset_xvf3510.py
+++ b/resources/clk_dac_setup/reset_xvf3510.py
@@ -30,6 +30,10 @@ def reset():
     bus.write_byte_data(0x20, 2, data_to_write)
     data_to_write = 0x20 | (state[6] & 0xDF)
     bus.write_byte_data(0x20, 6, data_to_write)
-
+    
+    # turn on level shifters on 3610 pi Hat
+    bus.write_byte_data(0x20, 3, 0x00)
+    bus.write_byte_data(0x20, 7, 0xD7)
+    
 if __name__ == "__main__":
     reset()

--- a/setup.sh
+++ b/setup.sh
@@ -51,8 +51,11 @@ sudo sed -i -e 's/dtparam=i2c_arm=on$/dtparam=i2c_arm=on\ndtparam=i2c_arm_baudra
 sudo raspi-config nonint do_spi 1
 sudo raspi-config nonint do_spi 0
 
-echo "Installing Raspberry Pi kernel headers"
-sudo apt-get install -y raspberrypi-kernel-headers
+KERNEL_HEADERS_PACKAGE=raspberrypi-kernel-headers
+if ! dpkg -s $KERNEL_HEADERS_PACKAGE &> /dev/null; then
+    echo "Installing Raspberry Pi kernel headers"
+    sudo apt-get install -y $KERNEL_HEADERS_PACKAGE
+fi
 
 echo "Installing the Python3 packages and related libs"
 sudo apt-get install -y python3-matplotlib

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,10 @@ sudo sed -i -e 's/dtparam=i2c_arm=on$/dtparam=i2c_arm=on\ndtparam=i2c_arm_baudra
 sudo raspi-config nonint do_spi 1
 sudo raspi-config nonint do_spi 0
 
+# Install the kernel header package to allow building the I2S module.
+# We only need to do this once, and we must not do it again if we have called
+# 'apt-get update' as it may install a later kernel and headers which have not
+# been tested and verified.
 KERNEL_HEADERS_PACKAGE=raspberrypi-kernel-headers
 if ! dpkg -s $KERNEL_HEADERS_PACKAGE &> /dev/null; then
     echo "Installing Raspberry Pi kernel headers"


### PR DESCRIPTION
3610 pithat needs level shifters turned on via I2C io expander so I2S can reach 1v8 IO on the chip