### PR TITLE
XVF600 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 4.2.0
 
-* Added support for xvf3600.
+  * Added support for xvf3600.
+  * Renamed I2S_CLK_DAC_SETUP flag to include I2S master configurations
 
 ## 4.1.0
 
-* Added support for xvf3610.
+  * Added support for xvf3610.
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 4.2.0
+
+* Added support for xvf3600.
+
 ## 4.1.0
 
 * Added support for xvf3610.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ For XVF3510 devices these actions will be done as well:
 
    https://www.raspberrypi.org/software/
 
-   Run the Raspberry Pi Imager, and select the 'CHOOSE OS' button. Scroll to the bottom of the displayed list, and select "Use custom". 
+   Run the Raspberry Pi Imager, and select the 'CHOOSE OS' button. Scroll to the bottom of the displayed list, and select "Use custom".
    Then select the file downloaded above (2020-02-13-raspbian-buster.zip) and select "Open". The archive file does not have to be unzipped, the imager software will do that.
 
    Select the CHOOSE SD CARD button to which to download the image, and then select the "WRITE" button.
 
-   When prompted, remove the written SD card and insert it into the Raspberry Pi. 
+   When prompted, remove the written SD card and insert it into the Raspberry Pi.
 
 2. Connect up the keyboard, mouse, speakers and display to the Raspberry Pi and power up the system. Refer to the **Getting Started Guide** for you platform.
 
@@ -60,7 +60,15 @@ For XVF3510 devices these actions will be done as well:
    For XVF3510 devices, run the installation script as follows:
 
    ```./setup.sh xvf3510```
-   
+
+   For XVF3600 I2S master devices, run the installation script as follows:
+
+   ```./setup.sh xvf3600-master```
+
+   For XVF3600 I2S slave devices, run the installation script as follows:
+
+   ```./setup.sh xvf3600-slave```
+
    For XVF3610 devices, run the installation script as follows:
 
    ```./setup.sh xvf3610```

--- a/resources/clk_dac_setup/reset_xvf.py
+++ b/resources/clk_dac_setup/reset_xvf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2021, XMOS Ltd, All rights reserved
+# Copyright (c) 2019-2021, XMOS Ltd, All rights reserved
 
 import argparse
 import smbus

--- a/resources/clk_dac_setup/reset_xvf.py
+++ b/resources/clk_dac_setup/reset_xvf.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2019, XMOS Ltd, All rights reserved
+# Copyright (c) 2021-2021, XMOS Ltd, All rights reserved
 
 import argparse
 import smbus
 
 def reset(args):
     """
-    Function to reset XVF3510 board
+    Function to reset XVF boards
 
     Args:
         args - command line arguments
@@ -36,12 +36,12 @@ def reset(args):
     bus.write_byte_data(0x20, 2, data_to_write)
     data_to_write = 0x20 | (state[6] & 0xDF)
     bus.write_byte_data(0x20, 6, data_to_write)
-    
+
     if level_shifter:
         # turn on level shifters on 3610 pi Hat
         bus.write_byte_data(0x20, 3, 0x00)
         bus.write_byte_data(0x20, 7, 0xD7)
-    
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("hw", help="Hardware type")

--- a/resources/clk_dac_setup/setup_dac.py
+++ b/resources/clk_dac_setup/setup_dac.py
@@ -3,6 +3,7 @@
 
 #run this on the raspberry pi to program the DAC
 
+import argparse
 import smbus
 import time
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ fi
 
 # Configure device-specific settings
 case $XMOS_DEVICE in
-  xvf3510|xvf3610|xvf3600)
+  xvf3[56]10)
     I2S_MODE=master
     I2S_CLK_DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf_xvf3510
@@ -24,6 +24,11 @@ case $XMOS_DEVICE in
     ;;
   xvf3100)
     I2S_MODE=slave
+    ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf
+    ;;
+  xvf3600)
+    I2S_MODE=master
+    I2S_CLK_DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf
     ;;
   *)

--- a/setup.sh
+++ b/setup.sh
@@ -174,8 +174,9 @@ if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
     echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_mclk"                  >> $i2s_clk_dac_script
     echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk"                  >> $i2s_clk_dac_script
   fi
-  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py $XMOS_DEVICE" >> $i2s_clk_dac_script
-  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/reset_xvf.py $XMOS_DEVICE" >> $i2s_clk_dac_script
+  # Note that only the substring xvfXXXX from $XMOS_DEVICE is used in the lines below
+  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $i2s_clk_dac_script
+  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/reset_xvf.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $i2s_clk_dac_script
 fi
 
 sudo apt-get install -y audacity

--- a/setup.sh
+++ b/setup.sh
@@ -170,7 +170,7 @@ if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
   i2s_clk_dac_script=$RPI_SETUP_DIR/resources/init_i2s_clks.sh
   rm -f $i2s_clk_dac_script
   # Configure the clocks only if RaspberryPi is configured as I2S master
-  if [["$I2S_MODE" == master ]] then
+  if [[ "$I2S_MODE" == "master" ]]; then
     echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_mclk"                  >> $i2s_clk_dac_script
     echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk"                  >> $i2s_clk_dac_script
   fi
@@ -179,13 +179,15 @@ if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
 fi
 
 sudo apt-get install -y audacity
-if [[ -n "$I2S_CLK_DAC_SETUP" && "$I2S_MODE" == master ]]; then
+if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
   audacity_script=$RPI_SETUP_DIR/resources/run_audacity.sh
   rm -f $audacity_script
   echo "#!/usr/bin/env bash" >> $audacity_script
   echo "/usr/bin/audacity &" >> $audacity_script
   echo "sleep 5" >> $audacity_script
-  echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk >> /dev/null" >> $audacity_script
+  if [[ "$I2S_MODE" == "master" ]]; then
+    echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk >> /dev/null" >> $audacity_script
+  fi
   sudo chmod +x $audacity_script
   sudo mv $audacity_script /usr/local/bin/audacity
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -161,7 +161,7 @@ if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
   rm -f $i2s_clk_dac_script
   echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_mclk"                  >> $i2s_clk_dac_script
   echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk"                  >> $i2s_clk_dac_script
-  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py"              >> $i2s_clk_dac_script
+  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py $XMOS_DEVICE" >> $i2s_clk_dac_script
   echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/reset_xvf.py $XMOS_DEVICE" >> $i2s_clk_dac_script
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ fi
 
 # Configure device-specific settings
 case $XMOS_DEVICE in
-  xvf3[56]10)
+  xvf3510|xvf3610|xvf3600)
     I2S_MODE=master
     I2S_CLK_DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf_xvf3510

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ fi
 case $XMOS_DEVICE in
   xvf3[56]10)
     I2S_MODE=master
-    I2S_CLK_DAC_SETUP=y
+    DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf_xvf3510
     ;;
   xvf3500)
@@ -28,12 +28,12 @@ case $XMOS_DEVICE in
     ;;
   xvf3600-slave)
     I2S_MODE=master
-    I2S_CLK_DAC_SETUP=y
+    DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf
     ;;
   xvf3600-master)
     I2S_MODE=slave
-    I2S_CLK_DAC_SETUP=y
+    DAC_SETUP=y
     ASOUNDRC_TEMPLATE=$RPI_SETUP_DIR/resources/asoundrc_vf
     ;;
   *)
@@ -163,24 +163,24 @@ echo "# Run Alsa at startup so that alsamixer configures" >> $i2s_driver_script
 echo "arecord -d 1 > /dev/null 2>&1"                      >> $i2s_driver_script	
 echo "aplay dummy > /dev/null 2>&1"                       >> $i2s_driver_script
 
-if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
+if [[ -n "$DAC_SETUP" ]]; then
   pushd $RPI_SETUP_DIR/resources/clk_dac_setup/ > /dev/null
   make
   popd > /dev/null
-  i2s_clk_dac_script=$RPI_SETUP_DIR/resources/init_i2s_clks.sh
-  rm -f $i2s_clk_dac_script
+  dac_and_clks_script=$RPI_SETUP_DIR/resources/init_dac_and_clks.sh
+  rm -f $dac_and_clks_script
   # Configure the clocks only if RaspberryPi is configured as I2S master
   if [[ "$I2S_MODE" == "master" ]]; then
-    echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_mclk"                  >> $i2s_clk_dac_script
-    echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk"                  >> $i2s_clk_dac_script
+    echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_mclk"                  >> $dac_and_clks_script
+    echo "sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk"                  >> $dac_and_clks_script
   fi
   # Note that only the substring xvfXXXX from $XMOS_DEVICE is used in the lines below
-  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $i2s_clk_dac_script
-  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/reset_xvf.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $i2s_clk_dac_script
+  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/setup_dac.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $dac_and_clks_script
+  echo "python $RPI_SETUP_DIR/resources/clk_dac_setup/reset_xvf.py $(echo $XMOS_DEVICE | cut -c1-7)" >> $dac_and_clks_script
 fi
 
 sudo apt-get install -y audacity
-if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
+if [[ -n "$DAC_SETUP" ]]; then
   audacity_script=$RPI_SETUP_DIR/resources/run_audacity.sh
   rm -f $audacity_script
   echo "#!/usr/bin/env bash" >> $audacity_script
@@ -196,8 +196,8 @@ fi
 # Setup the crontab to restart I2S at reboot
 rm -f $RPI_SETUP_DIR/resources/crontab
 echo "@reboot sh $i2s_driver_script" >> $RPI_SETUP_DIR/resources/crontab
-if [[ -n "$I2S_CLK_DAC_SETUP" ]]; then
-  echo "@reboot sh $i2s_clk_dac_script" >> $RPI_SETUP_DIR/resources/crontab
+if [[ -n "$DAC_SETUP" ]]; then
+  echo "@reboot sh $dac_and_clks_script" >> $RPI_SETUP_DIR/resources/crontab
 fi
 crontab $RPI_SETUP_DIR/resources/crontab
 


### PR DESCRIPTION
 - update scripts for XVF3600. 
 
 I tested successfully XVF3600 with RPI as I2S master and slave. I tested XVF3510 as well, in order to check if the setup_dac.py script is still working.