### PR TITLE
Add support for XVF3510-UA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 5.1.0
+
+  * Added support for xvf3510-ua
+  * Renamed xvf3510 device as xvf3510-int
+
 ## 5.0.0
 
   * Added support for xvf3610-ua and xvf3615-ua

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This setup will perform the following operations:
 - update the asoundrc file to support I2S devices
 - add a cron job to load the I2S drivers at boot up
 
-For XVF3510 devices these actions will be done as well:
+For XVF3510-INT devices these actions will be done as well:
 
 - configure MCLK at 24576kHz from pin 7 (BCM 4)
 - configure I2S BCLK at 3072kHz from pin 12 (BCM18)
@@ -32,7 +32,7 @@ For XVF361x-INT devices these actions will be done as well:
 - add a cron job to reset the device at boot up
 - add a cron job to configure the DAC at boot up
 
-For XVF361x-UA devices these actions will be done as well:
+For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
 - update the asoundrc file to support USB devices
 - update udev rules so that root privileges are not needed to access USB control interface

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ I2S_MODE=
 XMOS_DEVICE=
 
 # Valid values for XMOS device
-VALID_XMOS_DEVICES="xvf3100 xvf3500 xvf3510 xvf3600-slave xvf3600-master xvf3610-int xvf3610-ua xvf3615-int xvf3615-ua"
+VALID_XMOS_DEVICES="xvf3100 xvf3500 xvf3510-int xvf3510-ua xvf3600-slave xvf3600-master xvf3610-int xvf3610-ua xvf3615-int xvf3615-ua"
 
 usage() {
   local VALID_XMOS_DEVICES_DISPLAY_STRING=


### PR DESCRIPTION
The  xvf3510-ua and xvf3510-int setups have been successfully tested by @kieran-kohtz.

Fixes https://github.com/xmos/vocalfusion-avs-setup/issues/53