### PR TITLE
Several fixes for setup.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.2.0
 
-  * Added copy of asoundrc file at bootup
+  * Added copying of asoundrc file at bootup
   * Fixed checks for installation of debian packages
   * Updated equality operators
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 5.1.1
+
+  * Fixed checks for installation of debian packages
+  * Updated equality operators
+
 ## 5.1.0
 
   * Added support for xvf3510-ua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
-## 5.1.1
+## 5.2.0
 
+  * Added copy of asoundrc file at bootup
   * Fixed checks for installation of debian packages
   * Updated equality operators
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ RPI_SETUP_DIR="$( pwd )"
 
 I2S_MODE=
 XMOS_DEVICE=
-
+INSTALL_ATTEMPT_NUM_MAX=10
 # Valid values for XMOS device
 VALID_XMOS_DEVICES="xvf3100 xvf3500 xvf3510-int xvf3510-ua xvf3600-slave xvf3600-master xvf3610-int xvf3610-ua xvf3615-int xvf3615-ua"
 
@@ -133,10 +133,12 @@ for package in $packages; do
   installed=0
   attempt_num=0
   while [ $installed -eq 0 ]; do
+    sleep 2
     attempt_num=$((attempt_num+1))
     sudo apt-get install -y $package && installed=1
-    if [[ $attempt_num -gt 2 ]]; then
-	    echo "Error: installation of package $package failed after $attempt_num attempts"
+    if [[ $attempt_num -gt $INSTALL_ATTEMPT_NUM_MAX ]]; then
+      echo "Error: installation of package $package failed after $attempt_num attempts"
+      echo "Please retry installation procedure."
       exit 1
     fi
   done

--- a/setup.sh
+++ b/setup.sh
@@ -271,7 +271,7 @@ popd > /dev/null
 fi
 # Setup the crontab to copy the .asoundrc file at reboot
 # Delay the action by 10 seconds to allow the host to boot up
-# This is needed to address the known issue:
+# This is needed to address the known issue in Raspian Buster:
 # https://forums.raspberrypi.com/viewtopic.php?t=295008
 echo "@reboot sleep 10 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $RPI_SETUP_DIR/resources/crontab
 

--- a/setup.sh
+++ b/setup.sh
@@ -133,7 +133,6 @@ for package in $packages; do
   installed=0
   attempt_num=0
   while [ $installed -eq 0 ]; do
-    sleep 2
     attempt_num=$((attempt_num+1))
     sudo apt-get install -y $package && installed=1
     if [[ $attempt_num -gt $INSTALL_ATTEMPT_NUM_MAX ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -188,26 +188,6 @@ if [[ -n "$UA_MODE" ]]; then
   sudo cp $RPI_SETUP_DIR/resources/99-xmos.rules /etc/udev/rules.d/
 fi
 
-# Move existing files to back up
-if [[ -e ~/.asoundrc ]]; then
-  chmod a+w ~/.asoundrc
-  cp ~/.asoundrc ~/.asoundrc.bak
-fi
-if [[ -e /usr/share/alsa/pulse-alsa.conf ]]; then
-  sudo mv /usr/share/alsa/pulse-alsa.conf  /usr/share/alsa/pulse-alsa.conf.bak
-fi
-
-# Check XMOS device for asoundrc selection.
-if [[ -z "$ASOUNDRC_TEMPLATE" ]]; then
-  echo Error: sound card config not known for XMOS device $XMOS_DEVICE.
-  exit 1
-fi
-cp $ASOUNDRC_TEMPLATE ~/.asoundrc
-
-# Make the asoundrc file read-only otherwise lxpanel rewrites it
-# as it doesn't support anything but a hardware type device
-chmod a-w ~/.asoundrc
-
 # Apply changes
 sudo /etc/init.d/alsa-utils restart
 
@@ -260,10 +240,11 @@ if [[ -n "$DAC_SETUP" ]]; then
   sudo mv $audacity_script /usr/local/bin/audacity
 fi
 
+# Replace crontab tasks
+rm -f $RPI_SETUP_DIR/resources/crontab
+
 # Setup the crontab to restart I2S at reboot
 if [ -n "$I2S_MODE" ] || [ -n "$DAC_SETUP" ]; then
-  rm -f $RPI_SETUP_DIR/resources/crontab
-
   if [[ -n "$I2S_MODE" ]]; then
     echo "@reboot sh $i2s_driver_script" >> $RPI_SETUP_DIR/resources/crontab
   fi
@@ -271,9 +252,33 @@ if [ -n "$I2S_MODE" ] || [ -n "$DAC_SETUP" ]; then
   if [[ -n "$DAC_SETUP" ]]; then
     echo "@reboot sh $dac_and_clks_script" >> $RPI_SETUP_DIR/resources/crontab
   fi
-  crontab $RPI_SETUP_DIR/resources/crontab
 popd > /dev/null
 fi
+
+# Move existing files to back up
+if [[ -e ~/.asoundrc ]]; then
+  chmod a+w ~/.asoundrc
+  cp ~/.asoundrc ~/.asoundrc.bak
+fi
+if [[ -e /usr/share/alsa/pulse-alsa.conf ]]; then
+  sudo mv /usr/share/alsa/pulse-alsa.conf  /usr/share/alsa/pulse-alsa.conf.bak
+fi
+
+# Check XMOS device for asoundrc selection.
+if [[ -z "$ASOUNDRC_TEMPLATE" ]]; then
+  echo Error: sound card config not known for XMOS device $XMOS_DEVICE.
+  exit 1
+fi
+
+
+# Setup the crontab to copy the .asoundrc file at reboot after few seconds
+# This is needed to address the known issue:
+# https://forums.raspberrypi.com/viewtopic.php?t=295008
+echo "@reboot sleep 10 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $RPI_SETUP_DIR/resources/crontab
+
+
+# Update crontab
+crontab $RPI_SETUP_DIR/resources/crontab
 
 echo "To enable all interfaces, this Raspberry Pi must be rebooted."
 


### PR DESCRIPTION
  * Added copying of asoundrc file at bootup to support latest version of Raspian Buster
  * Fixed checks for installation of debian packages
  * Updated equality operators
  
Addresses https://github.com/xmos/vocalfusion-avs-setup/issues/63