### PR TITLE
Increase sleep time at bootup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -273,7 +273,7 @@ fi
 # Delay the action by 10 seconds to allow the host to boot up
 # This is needed to address the known issue in Raspian Buster:
 # https://forums.raspberrypi.com/viewtopic.php?t=295008
-echo "@reboot sleep 10 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $RPI_SETUP_DIR/resources/crontab
+echo "@reboot sleep 15 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $RPI_SETUP_DIR/resources/crontab
 
 # Update crontab
 crontab $RPI_SETUP_DIR/resources/crontab


### PR DESCRIPTION
This change is necessary for RPi3.
Part of https://github.com/xmos/vocalfusion-avs-setup/issues/55