### PR TITLE
Feature/3800 disable mclk default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## 5.6.0
+
+  * No Pi->XVF3800 MCLK drive by default. Use xvf3800-int-dev-extmclk to enable this
+
 ## 5.5.0
 
   * Add tool for setting arbitrary I2S clock

--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ For XVF361x-INT devices these actions will be done as well:
 - add a cron job to reset the device at boot up
 - add a cron job to configure the DAC at boot up
 
-For XVF3800(ALL) devices these actions will be done as well:
+For XVF3800(DEFAULT) devices these actions will be done as well:
 
-- configure MCLK at 12288kHz from pin 7 (BCM 4)
 - configure I2S BCLK at 3072kHz from pin 12 (BCM 18)
 - update the alias for Audacity
 - update the asoundrc file to support I2S devices
 - add a cron job to reset the device at boot up
 - add a cron job to configure the IO expander at boot up
+
+For XVF3800-extmclk devices these actions will be done as well:
+- configure MCLK at 12288kHz from pin 7 (BCM 4) and drive to XVF3800
+
 
 For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
@@ -118,6 +121,9 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
    ```./setup.sh xvf3800-inthost```
 
+  For XVF3800-INTDEV-EXTMCLK devices, run the installation script as follows:
+
+   ```./setup.sh xvf3800-intdev-extmclk```
 
    Wait for the script to complete the installation. This can take several minutes.
 
@@ -125,7 +131,7 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
 ## Important note on clocks
 
-The I2S/PCM driver that is provided with rasbian does not support an MCLK output. However the 
+The I2S/PCM driver that is provided with raspbian does not support an MCLK output. However the 
 driver does have full ability to set the BCLK and LRCLK correctly for a given sample rate. As 
 the driver does not know about the MCLK it is likely to choose dividers for the clocks generators
 which are not phase locked to the MCLK. The script in this repo gets around this problem by 


### PR DESCRIPTION
Update the setup script so that MCLK is disabled by default

Part of https://github.com/xmos/sw_xvf3800/issues/502

Note, all users will need to pull this update when the firmware with https://github.com/xmos/sw_xvf3800/pull/535

- [ ] Do we need to update AVS setup to point at this? https://github.com/xmos/vocalfusion-avs-setup/blob/master/auto_install.sh#L10