### PR TITLE
Increase delay before copying asoundrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.8.0
 
   * Update instructions to allow software update of Raspbian packages
+  * Increase crontab delay for copying .asoundrc from 15 to 20 seconds
 
 ## 5.7.0
 

--- a/setup.sh
+++ b/setup.sh
@@ -297,10 +297,10 @@ popd > /dev/null
 fi
 
 # Setup the crontab to copy the .asoundrc file at reboot
-# Delay the action by 10 seconds to allow the host to boot up
+# Delay the action to allow the host to boot up
 # This is needed to address the known issue in Raspian Buster:
 # https://forums.raspberrypi.com/viewtopic.php?t=295008
-echo "@reboot sleep 15 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $crontab_file
+echo "@reboot sleep 20 && cp $ASOUNDRC_TEMPLATE ~/.asoundrc" >> $crontab_file
 
 # Update crontab
 crontab $crontab_file


### PR DESCRIPTION
At least 1 of our pis is showing that 15 seconds is too short. I tried 20 seconds and that fixed it.

A better solution would be to use pulseaudio instead of ALSA to play and record. I think it is worth investigation as this is the behaviour that the OS is expecting of us and I imagine this 20 second increase will not fix the problem forever

#74 