### PR TITLE
Update for Raspberry PI 4 and 5 with Raspberry Pi OS bookworm 64-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
 ## Setup
 
-1. First, obtain the required version of the Raspberry Pi operating system, which is available [here](https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2023-02-22/2023-02-21-raspios-bullseye-armhf.img.xz)
+1. First, obtain the required version of the Raspberry Pi operating system, which is available [here](https://downloads.raspberrypi.com/raspios_arm64/images/raspios_arm64-2024-11-19/2024-11-19-raspios-bookworm-arm64.img.xz)
 
    Then, install the Raspberry Pi Imager on a host computer. Raspberry Pi Imager is available [here](https://www.raspberrypi.org/software/)
 
    Run the Raspberry Pi Imager, and select the 'CHOOSE OS' button. Scroll to the bottom of the displayed list, and select "Use custom".
-   Then select the file downloaded above (2023-02-21-raspios-bullseye-armhf.img.xz) and select "Open". The archive file does not have to be unzipped, the imager software will do that.
+   Then select the file downloaded above (2024-11-19-raspios-bookworm-arm64.img.xz) and select "Open". The archive file does not have to be unzipped, the imager software will do that.
 
    Select the CHOOSE SD CARD button to which to download the image, and then select the "WRITE" button.
 
@@ -63,18 +63,7 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
    Set up the locale, username, password, network connection and update the software on the Raspberry Pi.
 
-**_NOTE:_** Host applications and scripts used by the XMOS products support only 32-bit Raspbian systems.
-
-3. Force the Raspberry Pi to use 32-bit kernels, by typing:
-
-   ```
-   sudo sh -c "echo 'arm_64bit=0' >> /boot/config.txt"
-   sudo reboot
-   ```
-
-   and wait for the Raspberry Pi to reboot.
-
-4. Update the Raspberry Pi package list and upgrade the packages to the latest version:
+3. Update the Raspberry Pi package list and upgrade the packages to the latest version:
 
     ```
     sudo apt-get update
@@ -82,11 +71,11 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
     sudo reboot
     ```
 
-5. On the Raspberry Pi, clone the Github repository below:
+4. On the Raspberry Pi, clone the Github repository below:
 
    ```git clone https://github.com/xmos/vocalfusion-rpi-setup```
 
-6. For VocalFusion devices, run the installation script as follows:
+5. For VocalFusion devices, run the installation script as follows:
 
    ```./setup.sh xvf3100```
 
@@ -136,7 +125,7 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
    Wait for the script to complete the installation. This can take several minutes.
 
-7. Reboot the Raspberry Pi.
+6. Reboot the Raspberry Pi.
 
 ## Important note on clocks
 

--- a/README.md
+++ b/README.md
@@ -63,19 +63,11 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
    Set up the locale, username, password, network connection and update the software on the Raspberry Pi.
 
-3. Update the Raspberry Pi package list and upgrade the packages to the latest version:
-
-    ```
-    sudo apt-get update
-    sudo apt-get upgrade
-    sudo reboot
-    ```
-
-4. On the Raspberry Pi, clone the Github repository below:
+3. On the Raspberry Pi, clone the Github repository below:
 
    ```git clone https://github.com/xmos/vocalfusion-rpi-setup```
 
-5. For VocalFusion devices, run the installation script as follows:
+4. For VocalFusion devices, run the installation script as follows:
 
    ```./setup.sh xvf3100```
 
@@ -125,7 +117,7 @@ For XVF3510-UA and XVF361x-UA devices these actions will be done as well:
 
    Wait for the script to complete the installation. This can take several minutes.
 
-6. Reboot the Raspberry Pi.
+5. Reboot the Raspberry Pi.
 
 ## Important note on clocks
 

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -21,7 +21,13 @@ N.B. playback vs capture is determined by the codec choice
 
 void device_release_callback(struct device *dev) { /* do nothing */ };
 
-#ifdef RPI_4B
+#if defined(RPI_5)
+    #ifdef I2S_MASTER
+        #define CARD_PLATFORM_STR   "1f000a0000.i2s"
+    #else
+        #define CARD_PLATFORM_STR   "1f000a4000.i2s"
+    #endif
+#elif defined(RPI_4B)
     #define CARD_PLATFORM_STR   "fe203000.i2s"
 #else
     #define CARD_PLATFORM_STR   "3f203000.i2s"

--- a/overlay/i2s-master-enable.dts
+++ b/overlay/i2s-master-enable.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s_clk_producer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/overlay/i2s-slave-enable.dts
+++ b/overlay/i2s-slave-enable.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s_clk_consumer>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/setup.sh
+++ b/setup.sh
@@ -251,7 +251,12 @@ if [[ -n "$I2S_MODE" ]]; then
 
   I2S_NAME=i2s_$I2S_MODE
   I2S_MODULE=$RPI_SETUP_DIR/loader/$I2S_NAME/${I2S_NAME}_loader.ko
-  echo "sudo insmod $I2S_MODULE"                            >> $i2s_driver_script
+  echo "if sudo insmod $I2S_MODULE ; then"                  >> $i2s_driver_script
+  echo "  pushd $I2S_BUILD_DIR > /dev/null"                 >> $i2s_driver_script
+  echo "  eval $CMD"                                        >> $i2s_driver_script
+  echo "  popd > /dev/null"                                 >> $i2s_driver_script
+  echo "  sudo insmod $I2S_MODULE"                          >> $i2s_driver_script
+  echo "fi"                                                 >> $i2s_driver_script
 
   echo "# Run Alsa at startup so that alsamixer configures" >> $i2s_driver_script	
   echo "arecord -d 1 > /dev/null 2>&1"                      >> $i2s_driver_script	

--- a/setup.sh
+++ b/setup.sh
@@ -114,11 +114,15 @@ case $I2S_MODE in
   master)
     dtc -@ -H epapr -O dtb -o $RPI_SETUP_DIR/overlay/i2s-master-enable.dtbo -Wno-unit_address_vs_reg $RPI_SETUP_DIR/overlay/i2s-master-enable.dts
     sudo mv $RPI_SETUP_DIR/overlay/i2s-master-enable.dtbo /boot/firmware/overlays/
+    sudo sed -i -e 's/dtparam=i2s=on/#dtparam=i2s=on/' /boot/firmware/config.txt
+    sudo sed -i -e '/^dtoverlay=i2s-/d' /boot/firmware/config.txt
     sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on\ndtoverlay=i2s-master-enable/' /boot/firmware/config.txt
     ;;
   slave)
     dtc -@ -H epapr -O dtb -o $RPI_SETUP_DIR/overlay/i2s-slave-enable.dtbo -Wno-unit_address_vs_reg $RPI_SETUP_DIR/overlay/i2s-slave-enable.dts
     sudo mv $RPI_SETUP_DIR/overlay/i2s-slave-enable.dtbo /boot/firmware/overlays/
+    sudo sed -i -e 's/dtparam=i2s=on/#dtparam=i2s=on/' /boot/firmware/config.txt
+    sudo sed -i -e '/^dtoverlay=i2s-/d' /boot/firmware/config.txt
     sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on\ndtoverlay=i2s-slave-enable/' /boot/firmware/config.txt
     ;;
   *)

--- a/setup.sh
+++ b/setup.sh
@@ -107,18 +107,33 @@ esac
 
 # Disable the built-in audio output so there is only one audio
 # device in the system
-sudo sed -i -e 's/^dtparam=audio=on/#dtparam=audio=on/' /boot/config.txt
+sudo sed -i -e 's/^dtparam=audio=on/#dtparam=audio=on/' /boot/firmware/config.txt
 
 # Enable the i2s device tree
-sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on/' /boot/config.txt
+case $I2S_MODE in
+  master)
+    dtc -@ -H epapr -O dtb -o $RPI_SETUP_DIR/overlay/i2s-master-enable.dtbo -Wno-unit_address_vs_reg $RPI_SETUP_DIR/overlay/i2s-master-enable.dts
+    sudo mv $RPI_SETUP_DIR/overlay/i2s-master-enable.dtbo /boot/firmware/overlays/
+    sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on\ndtoverlay=i2s-master-enable/' /boot/firmware/config.txt
+    ;;
+  slave)
+    dtc -@ -H epapr -O dtb -o $RPI_SETUP_DIR/overlay/i2s-slave-enable.dtbo -Wno-unit_address_vs_reg $RPI_SETUP_DIR/overlay/i2s-slave-enable.dts
+    sudo mv $RPI_SETUP_DIR/overlay/i2s-slave-enable.dtbo /boot/firmware/overlays/
+    sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on\ndtoverlay=i2s-slave-enable/' /boot/firmware/config.txt
+    ;;
+  *)
+    echo Error: I2S mode not known for XMOS device $XMOS_DEVICE.
+    exit 1
+  ;;
+esac
 
 # Enable the I2C device tree
 sudo raspi-config nonint do_i2c 1
 sudo raspi-config nonint do_i2c 0
 
 # Set the I2C baudrate to 100k
-sudo sed -i -e '/^dtparam=i2c_arm_baudrate/d' /boot/config.txt
-sudo sed -i -e 's/dtparam=i2c_arm=on$/dtparam=i2c_arm=on\ndtparam=i2c_arm_baudrate=100000/' /boot/config.txt
+sudo sed -i -e '/^dtparam=i2c_arm_baudrate/d' /boot/firmware/config.txt
+sudo sed -i -e 's/dtparam=i2c_arm=on$/dtparam=i2c_arm=on\ndtparam=i2c_arm_baudrate=100000/' /boot/firmware/config.txt
 
 # Enable the SPI support
 sudo raspi-config nonint do_spi 1
@@ -155,7 +170,9 @@ for package in $packages; do
 done
 # Build I2S kernel module
 PI_MODEL=$(cat /proc/device-tree/model | awk '{print $3}')
-if [[ $PI_MODEL -eq 4 ]]; then
+if [[ $PI_MODEL -eq 5 ]]; then
+  I2S_MODULE_CFLAGS="-DRPI_5"
+elif [[ $PI_MODEL -eq 4 ]]; then
   I2S_MODULE_CFLAGS="-DRPI_4B"
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -252,9 +252,10 @@ if [[ -n "$I2S_MODE" ]]; then
   I2S_NAME=i2s_$I2S_MODE
   I2S_MODULE=$RPI_SETUP_DIR/loader/$I2S_NAME/${I2S_NAME}_loader.ko
   echo "if sudo insmod $I2S_MODULE ; then"                  >> $i2s_driver_script
-  echo "  pushd $I2S_BUILD_DIR > /dev/null"                 >> $i2s_driver_script
-  echo "  eval $CMD"                                        >> $i2s_driver_script
-  echo "  popd > /dev/null"                                 >> $i2s_driver_script
+  echo "  echo $I2S_MODULE loaded successfully"             >> $i2s_driver_script
+  echo "else"                                               >> $i2s_driver_script
+  echo "  cd $I2S_BUILD_DIR"                                >> $i2s_driver_script
+  echo "  $CMD"                                             >> $i2s_driver_script
   echo "  sudo insmod $I2S_MODULE"                          >> $i2s_driver_script
   echo "fi"                                                 >> $i2s_driver_script
 


### PR DESCRIPTION
Added:
- **Device tree overlays**:
  Two device tree overlays files to enable i2s producer or consumer, a replacement of `dtparam=i2s=on`

Updated:
- **setup.sh**: 
  - Compile device tree overlays file and move to `/boot/firmware/overlays/`
  - Update `/boot/firmware/config.txt` instead of `/boot/config.txt`, as bookworm stores config.txt in `/boot/firmware` now
  - I2S module compile flag when running on PI 5
  - Auto generated `i2s_driver_script` will recompile I2S module if the `insmod` failed
- **loader.c**:
  Set `CARD_PLATFORM_STR` to different value if the platform is PI 5 in i2s master or slave mode
- **README.md**:
  Instruct users to use the 64-bit bookworm Raspberry Pi OS and remove instruction of enable 32-bit mode

Part of LSM-186