### PR TITLE
Touch crontab file after deletion

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -447,6 +447,7 @@ fi
 
 info "Removing crontab file $crontab_file"
 rm -f $crontab_file
+touch $crontab_file
 
 # Setup the crontab to restart I2S at reboot
 if [[ -n "$i2s_mode" ]]; then


### PR DESCRIPTION
This is just a safety measure I missed, in case we hit a case where we don't generate a new crontab file (because we don't need to do anything at boot) but something is expecting it to exist.