### PR TITLE
Add xvf3800-intdev-master: I2S slave mode for RPi 4 and 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # VocalFusion Raspberry Pi Setup Change Log
 
+## Unreleased
+
+  * Add `xvf3800-intdev-master` device type for XVF3800 in I2S master mode
+  * Add I2S slave devicetree overlays for RPi 4 and RPi 5
+  * Fix `--no-packages` flag causing false package validation failures
+
 ## 6.0.0
 
   * Remove support for xvf3100, xvf3500, xvf3510, xvf3600, and xvf3615 (may work with other board configurations)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Finally, the setup will prompt you to restart your Raspberry Pi, this is require
 | XVF3610-UA             | Yes            | Yes            |
 | XVF3800-INTDEV-EXTMCLK | Yes            | No [^1]        |
 | XVF3800-INTDEV         | Yes            | Yes            |
+| XVF3800-INTDEV-MASTER  | Yes            | Yes            |
 | XVF3800-UA             | Yes            | Yes            |
 
 [^1]: These configurations are not supported due to missing Raspberry Pi documentation, see [here](https://github.com/raspberrypi/documentation/issues/3285).
@@ -66,6 +67,11 @@ Finally, the setup will prompt you to restart your Raspberry Pi, this is require
    For example, an XVF3800 in intdev configuration with a 48kHz sample rate (the default sample rate):
    ```bash
    ./setup.sh xvf3800-intdev
+   ```
+
+   or, for an XVF3800 in I2S master mode (RPi as clock slave):
+   ```bash
+   ./setup.sh xvf3800-intdev-master
    ```
 
    or, for an XVF3800 in EXTMCLK configuration with 16kHz sample rate:

--- a/overlays/Makefile
+++ b/overlays/Makefile
@@ -1,10 +1,26 @@
 RPI_CONFIG_ROOT ?= /boot
 
+# OVERLAY_MODE: master (default, RPi provides clocks) or slave (XVF3800 provides clocks)
+OVERLAY_MODE ?= master
+
+# RPI_MODEL: 4 (default) or 5 — selects the appropriate slave DTS
+RPI_MODEL ?= 4
+
+ifeq ($(OVERLAY_MODE),slave)
+  ifeq ($(RPI_MODEL),5)
+    DTS_SOURCE = xmos-device-slave-rpi5.dts
+  else
+    DTS_SOURCE = xmos-device-slave.dts
+  endif
+else
+  DTS_SOURCE = xmos-device.dts
+endif
+
 .PHONY: all
 all: xmos-device.dtbo
 
-xmos-device.dtbo: xmos-device.dts
-	dtc -@ -I dts -O dtb -o xmos-device.dtbo xmos-device.dts
+xmos-device.dtbo: $(DTS_SOURCE)
+	dtc -@ -I dts -O dtb -o xmos-device.dtbo $(DTS_SOURCE)
 
 install: xmos-device.dtbo
 	sudo cp xmos-device.dtbo ${RPI_CONFIG_ROOT}/overlays

--- a/overlays/xmos-device-slave-rpi5.dts
+++ b/overlays/xmos-device-slave-rpi5.dts
@@ -1,0 +1,112 @@
+// Device tree overlay for XMOS I2S audio devices — RPi 5 as I2S clock consumer
+//
+// This overlay is for configurations where the XVF3800 provides BCLK/LRCLK
+// (i.e., XVF3800 is the I2S master). Uses the i2s_clk_consumer controller
+// which is only available on Raspberry Pi 5 (BCM2712).
+//
+// RPi 5 has separate I2S controllers for master (i2s / i2s_clk_producer)
+// and slave (i2s_clk_consumer). The default &i2s node is master-only and
+// will reject slave clock configurations with -EINVAL.
+//
+// See: https://github.com/raspberrypi/linux/issues/5724
+//
+// For RPi 4, use xmos-device-slave.dts instead.
+/dts-v1/;
+/plugin/;
+
+/ {
+    // 2712 for RPi 5
+    compatible = "brcm,bcm2712";
+
+    fragment@0 {
+        target = <&sound>;
+        __overlay__ {
+            compatible = "simple-audio-card";
+            simple-audio-card,name = "XMOSDevice";
+            status = "okay";
+
+            // Capture
+            cap: simple-audio-card,dai-link@0 {
+                format = "i2s";
+
+                // XVF3800 as master (RPi as slave)
+                bitclock-master = <&cap_codec>;
+                frame-master = <&cap_codec>;
+
+                cap_cpu: cpu {
+                    sound-dai = <&i2s_clk_consumer>;
+
+                    // Stereo
+                    dai-tdm-slot-num = <2>;
+                    // 32-Bit
+                    dai-tdm-slot-width = <32>;
+                };
+
+                cap_codec: codec {
+                    sound-dai = <&c_codec>;
+                };
+            };
+
+            // Playback
+            play: simple-audio-card,dai-link@1 {
+                format = "i2s";
+
+                // XVF3800 as master (RPi as slave)
+                bitclock-master = <&play_codec>;
+                frame-master = <&play_codec>;
+
+                play_cpu: cpu {
+                    sound-dai = <&i2s_clk_consumer>;
+
+                    // Stereo
+                    dai-tdm-slot-num = <2>;
+                    // 32-Bit
+                    dai-tdm-slot-width = <32>;
+                };
+
+                play_codec: codec {
+                    sound-dai = <&p_codec>;
+                };
+            };
+        };
+    };
+
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+            // Uses S/PDIF codec as a generic I2S driver.
+            c_codec: spdif-receiver {
+                compatible = "linux,spdif-dir";
+                status = "okay";
+                #address-cells = <0>;
+                #size-cells = <0>;
+                #sound-dai-cells = <0>;
+            };
+
+            p_codec: spdif-transmitter {
+                compatible = "linux,spdif-dit";
+                status = "okay";
+                #address-cells = <0>;
+                #size-cells = <0>;
+                #sound-dai-cells = <0>;
+            };
+        };
+    };
+
+    // Enable the slave I2S controller
+    fragment@2 {
+        target = <&i2s_clk_consumer>;
+        __overlay__ {
+            status = "okay";
+            #sound-dai-cells = <0>;
+        };
+    };
+
+    // Disable the master I2S controller to prevent pin conflict
+    fragment@3 {
+        target = <&i2s>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+};

--- a/overlays/xmos-device-slave.dts
+++ b/overlays/xmos-device-slave.dts
@@ -1,0 +1,97 @@
+// Device tree overlay for XMOS I2S audio devices — RPi as I2S clock slave
+//
+// This overlay is for configurations where the XVF3800 provides BCLK/LRCLK
+// (i.e., XVF3800 is the I2S master). Uses the standard &i2s node which can
+// accept external clocks on Raspberry Pi 4.
+//
+// For RPi 5, use xmos-device-slave-rpi5.dts instead (i2s_clk_consumer).
+/dts-v1/;
+/plugin/;
+
+/ {
+    // 2835 for RPi 4
+    compatible = "brcm,bcm2835";
+
+    fragment@0 {
+        target = <&sound>;
+        __overlay__ {
+            compatible = "simple-audio-card";
+            simple-audio-card,name = "XMOSDevice";
+            status = "okay";
+
+            // Capture
+            cap: simple-audio-card,dai-link@0 {
+                format = "i2s";
+
+                // XVF3800 as master (RPi as slave)
+                bitclock-master = <&cap_codec>;
+                frame-master = <&cap_codec>;
+
+                cap_cpu: cpu {
+                    sound-dai = <&i2s>;
+
+                    // Stereo
+                    dai-tdm-slot-num = <2>;
+                    // 32-Bit
+                    dai-tdm-slot-width = <32>;
+                };
+
+                cap_codec: codec {
+                    sound-dai = <&c_codec>;
+                };
+            };
+
+            // Playback
+            play: simple-audio-card,dai-link@1 {
+                format = "i2s";
+
+                // XVF3800 as master (RPi as slave)
+                bitclock-master = <&play_codec>;
+                frame-master = <&play_codec>;
+
+                play_cpu: cpu {
+                    sound-dai = <&i2s>;
+
+                    // Stereo
+                    dai-tdm-slot-num = <2>;
+                    // 32-Bit
+                    dai-tdm-slot-width = <32>;
+                };
+
+                play_codec: codec {
+                    sound-dai = <&p_codec>;
+                };
+            };
+        };
+    };
+
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+            // Uses S/PDIF codec as a generic I2S driver.
+            c_codec: spdif-receiver {
+                compatible = "linux,spdif-dir";
+                status = "okay";
+                #address-cells = <0>;
+                #size-cells = <0>;
+                #sound-dai-cells = <0>;
+            };
+
+            p_codec: spdif-transmitter {
+                compatible = "linux,spdif-dit";
+                status = "okay";
+                #address-cells = <0>;
+                #size-cells = <0>;
+                #sound-dai-cells = <0>;
+            };
+        };
+    };
+
+    fragment@2 {
+        target = <&i2s>;
+        __overlay__ {
+            status = "okay";
+            #sound-dai-cells = <0>;
+        };
+    };
+};

--- a/setup.sh
+++ b/setup.sh
@@ -322,23 +322,25 @@ else
     info 'Skipping package install as --no-packages used.'
 fi
 
-info 'Checking required packages are installed.'
+if [[ -z "$no_packages" ]]; then
+    info 'Checking required packages are installed.'
 
-# Check for failed package installations
-for package in ${packages[@]}; do
-    debug "Checking $package..."
-    if ! dpkg -s $package &>/dev/null; then
-        failed_packages+=($package)
-        warn "Package $package failed to install."
+    # Check for failed package installations
+    for package in ${packages[@]}; do
+        debug "Checking $package..."
+        if ! dpkg -s $package &>/dev/null; then
+            failed_packages+=($package)
+            warn "Package $package failed to install."
+        fi
+    done
+
+    # Output failed packages
+    if (( ${#failed_packages[@]} > 0 )); then
+        error "Failed to install the following packages after $max_install_attempts attempts:"
+        printf '         - %s\n' "${failed_packages[@]}"
+        hint 'Please check network connection and package names, then try again.'
+        exit 1
     fi
-done
-
-# Output failed packages
-if (( ${#failed_packages[@]} > 0 )); then
-    error "Failed to install the following packages after $max_install_attempts attempts:"
-    printf '         - %s\n' "${failed_packages[@]}"
-    hint 'Please check network connection and package names, then try again.'
-    exit 1
 fi
 
 # Install XMOS devicetree overlay

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 rpi_setup_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 # Valid/supported device configurations
-valid_xmos_devices=(xvf3800-intdev-extmclk xvf3800-intdev xvf3800-ua xvf3610-int xvf3610-ua)
+valid_xmos_devices=(xvf3800-intdev-extmclk xvf3800-intdev xvf3800-intdev-master xvf3800-ua xvf3610-int xvf3610-ua)
 
 # Comma and space separate the devices
 printf -v devices_display_string '%s, ' "${valid_xmos_devices[@]}"
@@ -173,6 +173,13 @@ case $xmos_device in
     xvf3800-intdev)
         i2s_mode=master
         io_exp_and_dac_setup=y
+        asoundrc_template=$rpi_setup_dir/resources/asoundrc_vf
+        ;;
+    xvf3800-intdev-master)
+        # XVF3800 is I2S master, RPi is slave
+        # No clock setup needed (XVF3800 provides BCLK/LRCLK)
+        i2s_mode=slave
+        overlay_mode=slave
         asoundrc_template=$rpi_setup_dir/resources/asoundrc_vf
         ;;
     xvf3610-int)
@@ -345,8 +352,17 @@ fi
 
 # Install XMOS devicetree overlay
 if [[ -z "$usb_mode" ]]; then
+    # Detect RPi model for overlay selection
+    rpi_model_num=4
+    if [[ -f /proc/device-tree/model ]]; then
+        model_str=$(tr -d '\0' < /proc/device-tree/model)
+        if [[ "$model_str" == *"Raspberry Pi 5"* ]]; then
+            rpi_model_num=5
+        fi
+    fi
+
     info 'Making and installing XMOS DTO.'
-    RPI_CONFIG_ROOT=$rpi_config_root make -C $rpi_setup_dir/overlays install
+    RPI_CONFIG_ROOT=$rpi_config_root OVERLAY_MODE=${overlay_mode:-master} RPI_MODEL=$rpi_model_num make -C $rpi_setup_dir/overlays install
 
     # Enable XMOS devicetree overlay
     info 'Enabling DTO now.'


### PR DESCRIPTION
## Summary

- Add `xvf3800-intdev-master` device type for XVF3800 in I2S master mode (RPi as clock slave)
- Add I2S slave devicetree overlays for both RPi 4 (`&i2s`) and RPi 5 (`&i2s_clk_consumer`)
- Auto-detect RPi model to select the appropriate overlay
- Fix `--no-packages` flag causing false package validation failures

## Detail

When using XVF3800 with I2S master firmware (e.g. `respeaker_xvf3800_i2s_master_dfu_firmware`), the XVF3800 provides BCLK/LRCLK and the RPi must act as clock slave. The existing `xvf3800-intdev` configuration assumes RPi as I2S master, which causes clock collision.

### RPi 4 vs RPi 5

RPi 5 (BCM2712) has separate I2S controllers for master (`i2s` / `i2s_clk_producer`) and slave (`i2s_clk_consumer`). The default `&i2s` node is master-only and rejects slave configurations with `-EINVAL`.

The setup script detects the RPi model via `/proc/device-tree/model` and passes `RPI_MODEL` to the Makefile, which selects the correct DTS source:

| RPi Model | DTS | I2S Node |
|-----------|-----|----------|
| RPi 4 | `xmos-device-slave.dts` | `&i2s` |
| RPi 5 | `xmos-device-slave-rpi5.dts` | `&i2s_clk_consumer` |

### No clock setup needed

Since the XVF3800 provides BCLK and LRCLK, the `xvf3800-intdev-master` configuration skips clock/DAC setup entirely.

## Usage

```bash
./setup.sh xvf3800-intdev-master
```